### PR TITLE
use objc_msgSend for Apple Silicon chips

### DIFF
--- a/src/message.v
+++ b/src/message.v
@@ -205,4 +205,8 @@ fn get_msg_send_fn[R]() FnSendMsgGeneric {
 			return C.objc_msgSend_stret
 		}
 	}
+
+	// TODO: this is needed according to the discussion in issue #1. Improved code in this function after
+	//	having an Apple Silicon device.
+	return C.objc_msgSend
 }


### PR DESCRIPTION
## What
Fix issue #1.  The `objc_msgSend_stret()` is not available on Apple Silicon chips. Always use `objc_msgSend` for `arm64` platform.

Referred to a similar fix in another project: https://github.com/veldrid/veldrid/pull/449.